### PR TITLE
Wrap all streams with ObserveOn

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,22 +4,27 @@ buildscript {
     project.ext.DEPLOYMENT = System.getProperty('deployment') ?: false
     project.ext.VCS_TAG = System.getProperty('TRAVIS_TAG') ?: System.getenv('TRAVIS_TAG')
     project.ext.POM = [
-            groupId   : 'org.streamingpool',
-            artifactId: 'streamingpool-core',
-            description: 'This project is an high level abstraction over Reactive Streams libraries that is currently used inside CERN.'
+            groupId    : 'org.streamingpool',
+            artifactId : 'streamingpool-core',
+            description: 'This project is an high level abstraction over Reactive Streams libraries that is currently used inside CERN.',
+            developers : [[
+                                  id   : 'streamingpool-dev',
+                                  name : 'Streamingpool Developers',
+                                  email: 'streamingpool-dev@cern.ch'
+                          ]]
     ]
     project.ext.INFO = [
-            repo: 'https://github.com/streamingpool/streamingpool-core.git',
-            url: 'http://www.streamingpool.org/',
-            github: 'https://github.com/streamingpool/streamingpool-core',
+            repo        : 'https://github.com/streamingpool/streamingpool-core.git',
+            url         : 'http://www.streamingpool.org/',
+            github      : 'https://github.com/streamingpool/streamingpool-core',
             githubIssues: 'https://github.com/streamingpool/streamingpool-core/issues'
     ]
     project.ext.BINTRAY = [
-            repo: 'streamingpool-repos',
-            name: 'org.streamingpool:streamingpool-core',
+            repo        : 'streamingpool-repos',
+            name        : 'org.streamingpool:streamingpool-core',
             organization: 'streamingpool',
-            userName: 'streamingpool-dev',
-            apiToken: System.getenv('BINTRAY_API_TOKEN')
+            userName    : 'streamingpool-dev',
+            apiToken    : System.getenv('BINTRAY_API_TOKEN')
     ]
     repositories {
         if (CERN_VM) {

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ sourceCompatibility = 1.8
 dependencies {
     compile 'org.reactivestreams:reactive-streams:1.0.0'
     compile 'io.reactivex.rxjava2:rxjava:2.1.+'
+    compile group: 'io.projectreactor', name: 'reactor-core', version: '3.0.7.RELEASE'
     //compile 'com.typesafe.akka:akka-stream_2.11:2.4.16'
 
     //compile group: 'com.typesafe.akka', name: 'akka-stream_2.11', version:'2.5.3'

--- a/scripts/bintray-deploy.gradle
+++ b/scripts/bintray-deploy.gradle
@@ -52,10 +52,12 @@ def pomExtraInfo = {
         }
     }
     developers {
-        developer {
-            id 'streamingpool-dev'
-            name 'Streamingpool Developers'
-            email 'streamingpool-dev@cern.ch'
+        POM.developers.each { dev ->
+            developer {
+                id dev.id
+                name dev.name
+                email dev.email
+            }
         }
     }
 }

--- a/src/java/org/streamingpool/core/conf/DefaultSchedulerConfiguration.java
+++ b/src/java/org/streamingpool/core/conf/DefaultSchedulerConfiguration.java
@@ -1,0 +1,66 @@
+// @formatter:off
+/*
+*
+* This file is part of streaming pool (http://www.streamingpool.org).
+*
+* Copyright (c) 2017-present, CERN. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+// @formatter:on
+
+package org.streamingpool.core.conf;
+
+import static java.util.Arrays.stream;
+import static org.streamingpool.core.conf.TestSchedulerConfiguration.STREAMINGPOOL_TEST_SCHEDULER;
+
+import java.util.concurrent.Executors;
+
+import io.reactivex.Scheduler;
+import io.reactivex.schedulers.Schedulers;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@Configuration
+public class DefaultSchedulerConfiguration {
+
+    public static final String STREAMINGPOOL_THREAD_POOL_SIZE = "streamingpool.threadPoolSize";
+
+
+    @Value("${" + STREAMINGPOOL_THREAD_POOL_SIZE + ":100}")
+    private int threadPoolSize;
+
+    @Bean
+    @Conditional(NoTestSchedulerPresent.class)
+    public Scheduler scheduler(){
+        return Schedulers.from(Executors.newFixedThreadPool(threadPoolSize));
+    }
+
+    private static class NoTestSchedulerPresent implements Condition {
+        @Override
+        public boolean matches(ConditionContext context,
+                AnnotatedTypeMetadata metadata) {
+            Environment env = context.getEnvironment();
+            return !stream(env.getActiveProfiles()).anyMatch(STREAMINGPOOL_TEST_SCHEDULER::equals);
+        }
+    }
+
+
+}

--- a/src/java/org/streamingpool/core/conf/EmbeddedPoolConfiguration.java
+++ b/src/java/org/streamingpool/core/conf/EmbeddedPoolConfiguration.java
@@ -26,7 +26,11 @@ import static org.streamingpool.core.util.MoreCollections.emptyIfNull;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.streamingpool.core.service.StreamFactory;
@@ -48,6 +52,8 @@ import org.streamingpool.core.service.impl.LocalPool;
 @Configuration
 public class EmbeddedPoolConfiguration {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedPoolConfiguration.class);
+
     /**
      * A list of stream factories which will be automatically collected by Spring. Since there will be at least one (the
      * below created factory) we can keep the required=true (default).
@@ -55,8 +61,18 @@ public class EmbeddedPoolConfiguration {
     @Autowired(required = false)
     private List<StreamFactory> streamFactories;
 
+    @Value( "${bufferSize}" )
+    private int bufferSize;
+
+    @Bean
+    public String post(){
+        System.out.println("AAAAAAAAAAAAAAAAAAAAAAA "+bufferSize);
+        return "marek";
+    }
+
     @Bean
     public LocalPool pool() {
+       LOGGER.error("AAAAAAAAAAAAAAAAAAAAAAA "+bufferSize);
         return new LocalPool(emptyIfNull(streamFactories));
     }
 

--- a/src/java/org/streamingpool/core/conf/EmbeddedPoolConfiguration.java
+++ b/src/java/org/streamingpool/core/conf/EmbeddedPoolConfiguration.java
@@ -1,5 +1,5 @@
 // @formatter:off
-/**
+/*
 *
 * This file is part of streaming pool (http://www.streamingpool.org).
 *
@@ -26,13 +26,11 @@ import static org.streamingpool.core.util.MoreCollections.emptyIfNull;
 
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import io.reactivex.Scheduler;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.streamingpool.core.service.StreamFactory;
 import org.streamingpool.core.service.TypedStreamFactory;
 import org.streamingpool.core.service.impl.LocalPool;
@@ -50,9 +48,8 @@ import org.streamingpool.core.service.impl.LocalPool;
  * @author kfuchsbe
  */
 @Configuration
+@Import({TestSchedulerConfiguration.class, DefaultSchedulerConfiguration.class})
 public class EmbeddedPoolConfiguration {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedPoolConfiguration.class);
 
     /**
      * A list of stream factories which will be automatically collected by Spring. Since there will be at least one (the
@@ -61,19 +58,12 @@ public class EmbeddedPoolConfiguration {
     @Autowired(required = false)
     private List<StreamFactory> streamFactories;
 
-    @Value( "${bufferSize}" )
-    private int bufferSize;
-
-    @Bean
-    public String post(){
-        System.out.println("AAAAAAAAAAAAAAAAAAAAAAA "+bufferSize);
-        return "marek";
-    }
+    @Autowired
+    private Scheduler scheduler;
 
     @Bean
     public LocalPool pool() {
-       LOGGER.error("AAAAAAAAAAAAAAAAAAAAAAA "+bufferSize);
-        return new LocalPool(emptyIfNull(streamFactories));
+        return new LocalPool(emptyIfNull(streamFactories), scheduler);
     }
 
 }

--- a/src/java/org/streamingpool/core/conf/TestSchedulerConfiguration.java
+++ b/src/java/org/streamingpool/core/conf/TestSchedulerConfiguration.java
@@ -1,0 +1,43 @@
+// @formatter:off
+/*
+*
+* This file is part of streaming pool (http://www.streamingpool.org).
+*
+* Copyright (c) 2017-present, CERN. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+// @formatter:on
+
+package org.streamingpool.core.conf;
+
+import io.reactivex.schedulers.TestScheduler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile(TestSchedulerConfiguration.STREAMINGPOOL_TEST_SCHEDULER)
+public class TestSchedulerConfiguration {
+
+    public static final String STREAMINGPOOL_TEST_SCHEDULER = "streamingpool.test.scheduler";
+
+    @Bean
+    public TestScheduler scheduler(){
+        return new TestScheduler();
+    }
+
+
+
+}

--- a/src/java/org/streamingpool/core/domain/ErrorDeflector.java
+++ b/src/java/org/streamingpool/core/domain/ErrorDeflector.java
@@ -4,17 +4,18 @@
 
 package org.streamingpool.core.domain;
 
-import static io.reactivex.BackpressureStrategy.DROP;
-
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import io.reactivex.BackpressureOverflowStrategy;
 import io.reactivex.Flowable;
-import io.reactivex.subjects.PublishSubject;
+import io.reactivex.processors.PublishProcessor;
 
 /**
  * Provides different ways to intercept exceptions from streams (or lambdas) and deflect the caught exceptions onto an
@@ -27,9 +28,11 @@ import io.reactivex.subjects.PublishSubject;
  * streams.
  */
 public final class ErrorDeflector {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(ErrorDeflector.class);
 
     /** The subject onto which all the errors will be forwarded */
-    private final PublishSubject<Throwable> errorStream = PublishSubject.create();
+    private final PublishProcessor<Throwable> errorStream = PublishProcessor.create();
 
     /**
      * Private constructor to avoid instantiation. Use the factory method {@link #create()}.
@@ -125,8 +128,8 @@ public final class ErrorDeflector {
         return falseOnException(predicate);
     }
 
-    public PublishSubject<Throwable> errorSubject() {
-        return this.errorSubject();
+    public void publishException(Throwable exception) {
+        errorStream.onNext(exception);
     }
 
     private <T> void deflectOperationIncomingError(Object operation, T incoming, Exception e) {
@@ -141,7 +144,10 @@ public final class ErrorDeflector {
     }
 
     public <T> ErrorStreamPair<T> stream(Publisher<T> dataPublisher) {
-        return ErrorStreamPair.ofDataError(dataPublisher, errorStream.toFlowable(DROP));
+        return ErrorStreamPair.ofDataError(dataPublisher,
+                errorStream.toSerialized().onBackpressureBuffer(10,
+                        () -> LOGGER.error("Discarding exception due to backpressure buffer limit"),
+                        BackpressureOverflowStrategy.DROP_OLDEST));
     }
 
     public <T> ErrorStreamPair<T> streamNonEmpty(Publisher<Optional<T>> optionalPublisher) {

--- a/src/java/org/streamingpool/core/domain/ErrorDeflector.java
+++ b/src/java/org/streamingpool/core/domain/ErrorDeflector.java
@@ -145,7 +145,7 @@ public final class ErrorDeflector {
 
     public <T> ErrorStreamPair<T> stream(Publisher<T> dataPublisher) {
         return ErrorStreamPair.ofDataError(dataPublisher,
-                errorStream.toSerialized().onBackpressureBuffer(10,
+                errorStream.toSerialized().onBackpressureBuffer(Flowable.bufferSize(),
                         () -> LOGGER.error("Discarding exception due to backpressure buffer limit"),
                         BackpressureOverflowStrategy.DROP_OLDEST));
     }

--- a/src/java/org/streamingpool/core/domain/ErrorDeflector.java
+++ b/src/java/org/streamingpool/core/domain/ErrorDeflector.java
@@ -19,16 +19,16 @@ import io.reactivex.processors.PublishProcessor;
 
 /**
  * Provides different ways to intercept exceptions from streams (or lambdas) and deflect the caught exceptions onto an
- * error stream. The error stream (subject) is created internally. It can be retrieved by the {@link #errorSubject()}
- * method in order to post external events onto it. Further it will be included in the errors stream pair in case the
- * two factory methods for these are used ({@link #stream(Publisher)} or {@link #streamNonEmpty(Publisher)}).
+ * error stream. The error stream (subject) is created internally. An external event can be pushed onto it bu using the
+ * {@link #publishException(Throwable)} method. Further it will be included in the errors stream pair in case the two
+ * factory methods for these are used ({@link #stream(Publisher)} or {@link #streamNonEmpty(Publisher)}).
  * <p>
  * Since one error stream usually corresponds to one data stream, each time a new stream is created, a new instance of
  * an error deflector should be created, so that the contained error stream is not shared between different data
  * streams.
  */
 public final class ErrorDeflector {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ErrorDeflector.class);
 
     /** The subject onto which all the errors will be forwarded */

--- a/src/java/org/streamingpool/core/service/impl/LocalPool.java
+++ b/src/java/org/streamingpool/core/service/impl/LocalPool.java
@@ -60,18 +60,6 @@ public class LocalPool implements DiscoveryService, ProvidingService, StreamFact
     private final List<StreamFactory> factories;
     private final PoolContent content = new PoolContent();
 
-    public LocalPool() {
-        this(Collections.emptyList());
-    }
-
-    public LocalPool(List<StreamFactory> factories) {
-        this(factories, defaultScheduler());
-    }
-
-    private static Scheduler defaultScheduler() {
-        return Schedulers.from(Executors.newFixedThreadPool(DEFAULT_THREAD_POOL_SIZE));
-    }
-
     public LocalPool(List<StreamFactory> factories, Scheduler scheduler) {
         java.util.Objects.requireNonNull(factories,"Factories can not be null");
         this.factories = new CopyOnWriteArrayList<>(factories);

--- a/src/java/org/streamingpool/core/service/impl/TrackKeepingDiscoveryService.java
+++ b/src/java/org/streamingpool/core/service/impl/TrackKeepingDiscoveryService.java
@@ -1,5 +1,5 @@
 // @formatter:off
-/**
+/*
 *
 * This file is part of streaming pool (http://www.streamingpool.org).
 * 
@@ -83,7 +83,6 @@ public class TrackKeepingDiscoveryService implements DiscoveryService {
 
     private <T> Publisher<T> applyBackpressure(Publisher<T> publisher) {
         return Flowable.fromPublisher(publisher)
-                .onBackpressureLatest()
                 .observeOn(scheduler, false, 1);
     }
 
@@ -131,7 +130,7 @@ public class TrackKeepingDiscoveryService implements DiscoveryService {
 
             if (factoryResult.isPresent()) {
                 LOGGER.info(format("Stream from id '%s' was successfully created by factory '%s'", newId, factory));
-                Flowable<T> sharedDataStream = Flowable.fromPublisher(factoryResult.data()).share();
+                Flowable<T> sharedDataStream = Flowable.fromPublisher(factoryResult.data());
                 return ErrorStreamPair.ofDataError(sharedDataStream, factoryResult.error());
             }
         }

--- a/src/java/org/streamingpool/core/service/impl/TrackKeepingDiscoveryService.java
+++ b/src/java/org/streamingpool/core/service/impl/TrackKeepingDiscoveryService.java
@@ -130,8 +130,7 @@ public class TrackKeepingDiscoveryService implements DiscoveryService {
 
             if (factoryResult.isPresent()) {
                 LOGGER.info(format("Stream from id '%s' was successfully created by factory '%s'", newId, factory));
-                Flowable<T> sharedDataStream = Flowable.fromPublisher(factoryResult.data());
-                return ErrorStreamPair.ofDataError(sharedDataStream, factoryResult.error());
+                return ErrorStreamPair.ofDataError(factoryResult.data(), factoryResult.error());
             }
         }
         return ErrorStreamPair.empty();

--- a/src/java/org/streamingpool/core/service/streamfactory/CombineWithLatestStreamFactory.java
+++ b/src/java/org/streamingpool/core/service/streamfactory/CombineWithLatestStreamFactory.java
@@ -22,14 +22,14 @@
 
 package org.streamingpool.core.service.streamfactory;
 
+import io.reactivex.Flowable;
 import org.reactivestreams.Publisher;
 import org.streamingpool.core.domain.ErrorStreamPair;
 import org.streamingpool.core.service.DiscoveryService;
 import org.streamingpool.core.service.StreamFactory;
 import org.streamingpool.core.service.StreamId;
 import org.streamingpool.core.service.streamid.CombineWithLatestStreamId;
-
-import io.reactivex.Flowable;
+import reactor.core.publisher.Flux;
 
 /**
  * Factory for {@link CombineWithLatestStreamId}
@@ -54,7 +54,8 @@ public class CombineWithLatestStreamFactory implements StreamFactory {
         Flowable<D> data = Flowable.fromPublisher(discoveryService.discover(streamId.dataStream()));
         Flowable<T> trigger = Flowable.fromPublisher(discoveryService.discover(streamId.triggerStream()));
 
-        return trigger.withLatestFrom(data, streamId.combiner()::apply);
+        //TODO remove the Flux once RxJava2 has been released with the bug fix (version 2.2)
+        return Flux.from(trigger).withLatestFrom(data, streamId.combiner()::apply);
     }
 
 }

--- a/src/java/org/streamingpool/core/service/streamfactory/CombineWithLatestStreamFactory.java
+++ b/src/java/org/streamingpool/core/service/streamfactory/CombineWithLatestStreamFactory.java
@@ -54,7 +54,7 @@ public class CombineWithLatestStreamFactory implements StreamFactory {
         Flowable<D> data = Flowable.fromPublisher(discoveryService.discover(streamId.dataStream()));
         Flowable<T> trigger = Flowable.fromPublisher(discoveryService.discover(streamId.triggerStream()));
 
-        //TODO remove the Flux once RxJava2 has been released with the bug fix (version 2.2)
+        /* TODO remove the Flux once RxJava2 has been released with the bug fix (version 2.2) */
         return Flux.from(trigger).withLatestFrom(data, streamId.combiner()::apply);
     }
 

--- a/src/java/org/streamingpool/core/testing/StreamFactoryMock.java
+++ b/src/java/org/streamingpool/core/testing/StreamFactoryMock.java
@@ -111,7 +111,6 @@ public class StreamFactoryMock<T> {
     public StreamFactory build() {
         final StreamFactory factoryMock = mock(StreamFactory.class);
         when(factoryMock.create(any(), any())).thenAnswer(args -> {
-            @SuppressWarnings("unchecked")
             StreamId<T> streamId = args.getArgument(0);
             DiscoveryService discovery = args.getArgument(1);
 

--- a/src/test/org/streamingpool/core/service/DiscoveryTest.java
+++ b/src/test/org/streamingpool/core/service/DiscoveryTest.java
@@ -28,7 +28,9 @@ import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Executors;
 
+import io.reactivex.schedulers.Schedulers;
 import org.assertj.core.util.Lists;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
@@ -109,7 +111,7 @@ public class DiscoveryTest {
     }
 
     private DiscoveryService prepareDiscoveryService(final List<StreamFactory> factories) {
-        return new LocalPool(factories);
+        return new LocalPool(factories, Schedulers.from(Executors.newSingleThreadExecutor()));
     }
 
     private List<String> toList(Publisher<String> result) {

--- a/src/test/org/streamingpool/core/service/MultiThreadLazyPoolTest.java
+++ b/src/test/org/streamingpool/core/service/MultiThreadLazyPoolTest.java
@@ -24,7 +24,6 @@ package org.streamingpool.core.service;
 
 import static org.mockito.Mockito.mock;
 
-import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -32,7 +31,6 @@ import java.util.concurrent.Future;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.streamingpool.core.service.impl.LocalPool;
 import org.streamingpool.core.testing.AbstractStreamTest;
 import org.streamingpool.core.testing.StreamFactoryMock;
 

--- a/src/test/org/streamingpool/core/service/MultiThreadLazyPoolTest.java
+++ b/src/test/org/streamingpool/core/service/MultiThreadLazyPoolTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Future;
 
 import org.junit.Test;
 import org.reactivestreams.Publisher;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.streamingpool.core.service.impl.LocalPool;
 import org.streamingpool.core.testing.AbstractStreamTest;
 import org.streamingpool.core.testing.StreamFactoryMock;
@@ -41,6 +42,9 @@ import org.streamingpool.core.testing.StreamFactoryMock;
 public class MultiThreadLazyPoolTest extends AbstractStreamTest {
 
     private static final String ANY_VALUE = "ANY_STRING";
+
+    @Autowired
+    private StreamFactoryRegistry factoryRegistry;
 
     @SuppressWarnings("unchecked")
     @Test(expected = RuntimeException.class)
@@ -65,10 +69,10 @@ public class MultiThreadLazyPoolTest extends AbstractStreamTest {
         StreamFactory factoryForAnyValue = StreamFactoryMock.newFactory(String.class)
                 .withIdProvideStreamWithValue(idB, ANY_VALUE).build();
 
-        prepareDiscoveryService(multiThreadFactory, factoryForAnyValue).discover(idA);
+        factoryRegistry.addIntercept(multiThreadFactory);
+        factoryRegistry.addIntercept(factoryForAnyValue);
+
+        discover(idA);
     }
 
-    private LocalPool prepareDiscoveryService(StreamFactory markerIdFactory, StreamFactory factoryForAnyValue) {
-        return new LocalPool(Arrays.asList(markerIdFactory, factoryForAnyValue));
-    }
 }

--- a/src/test/org/streamingpool/core/service/ProviderTest.java
+++ b/src/test/org/streamingpool/core/service/ProviderTest.java
@@ -22,37 +22,44 @@
 
 package org.streamingpool.core.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import io.reactivex.Flowable;
+import io.reactivex.subscribers.TestSubscriber;
 import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.streamingpool.core.support.RxStreamSupport;
 import org.streamingpool.core.testing.AbstractStreamTest;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SuppressWarnings({"unchecked", "rawtypes"})
-public class ProviderTest extends AbstractStreamTest {
-
-    private static final Publisher ANY_REACTIVE_STREAM = mock(Publisher.class);
+public class ProviderTest extends AbstractStreamTest implements RxStreamSupport{
+    private static final Publisher ANY_REACTIVE_STREAM = Flowable.just(1);
     private static final StreamId ANY_STREAM_ID = mock(StreamId.class);
     
     @Autowired
     ProvidingService providingService;
-    @Autowired
-    DiscoveryService discoveryService;
 
     @Test
     public void testProvidedStreamCanBeDiscovered() {
         providingService.provide(ANY_STREAM_ID, ANY_REACTIVE_STREAM);
-        assertThat(discoveryService.discover(ANY_STREAM_ID)).isNotNull().isEqualTo(ANY_REACTIVE_STREAM);
+
+        TestSubscriber test = rxFrom(ANY_STREAM_ID).test();
+        test.awaitTerminalEvent();
+        test.assertValueCount(1);
+        test.assertValue(1);
     }
 
     @Test
     public void testProvidedUsingHelpersIsDiscovered() {
         provide(ANY_REACTIVE_STREAM).as(ANY_STREAM_ID);
-        assertThat(discover(ANY_STREAM_ID)).isNotNull().isEqualTo(ANY_REACTIVE_STREAM);
+        TestSubscriber test = rxFrom(ANY_STREAM_ID).test();
+        test.awaitTerminalEvent();
+        test.assertValueCount(1);
+        test.assertValue(1);
     }
 }

--- a/src/test/org/streamingpool/core/service/StreamFactoryRegistryTest.java
+++ b/src/test/org/streamingpool/core/service/StreamFactoryRegistryTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFOR
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import io.reactivex.Flowable;
 import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
@@ -16,8 +18,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.streamingpool.core.conf.EmbeddedPoolConfiguration;
 import org.streamingpool.core.domain.ErrorStreamPair;
 import org.streamingpool.core.testing.NamedStreamId;
-
-import io.reactivex.Flowable;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = { EmbeddedPoolConfiguration.class })
@@ -43,22 +43,22 @@ public class StreamFactoryRegistryTest {
     public void testInterceptor() {
         factoryRegistry.addIntercept(new InterceptStreamFactory());
         Publisher<String> publisher = service.discover(ID);
-        Flowable.fromPublisher(publisher).test().assertValue(ANY_VALUE_1);
+        Flowable.fromPublisher(publisher).test().awaitCount(1).assertValue(ANY_VALUE_1);
     }
 
     @Test
     public void testFallback() {
         factoryRegistry.addFallback(new FallbackStreamFactory());
         Publisher<String> publisher = service.discover(ID);
-        Flowable.fromPublisher(publisher).test().assertValue(ANY_VALUE_2);
+        Flowable.fromPublisher(publisher).test().awaitCount(1).assertValue(ANY_VALUE_2);
     }
 
     @Test
-    public void testIntereceptorFirst() {
+    public void testInterceptorFirst() {
         factoryRegistry.addIntercept(new InterceptStreamFactory());
         factoryRegistry.addFallback(new FallbackStreamFactory());
         Publisher<String> publisher = service.discover(ID);
-        Flowable.fromPublisher(publisher).test().assertValue(ANY_VALUE_1);
+        Flowable.fromPublisher(publisher).test().awaitCount(1).assertValue(ANY_VALUE_1);
     }
 
     private static class InterceptStreamFactory implements StreamFactory {

--- a/src/test/org/streamingpool/core/service/impl/LocalPoolHookTest.java
+++ b/src/test/org/streamingpool/core/service/impl/LocalPoolHookTest.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.streamingpool.core.service.streamid.StreamingPoolHook.NEW_STREAM_HOOK;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import org.streamingpool.core.service.StreamId;

--- a/src/test/org/streamingpool/core/service/impl/LocalPoolHookTest.java
+++ b/src/test/org/streamingpool/core/service/impl/LocalPoolHookTest.java
@@ -35,18 +35,12 @@ import org.streamingpool.core.service.streamid.StreamingPoolHook;
 
 import io.reactivex.Flowable;
 import io.reactivex.subscribers.TestSubscriber;
+import org.streamingpool.core.testing.AbstractStreamTest;
 
 /**
  * Testing the behavior of new {@link StreamingPoolHook} hooks.
  */
-public class LocalPoolHookTest {
-
-    private LocalPool pool;
-
-    @Before
-    public void setUp() {
-        this.pool = new LocalPool();
-    }
+public class LocalPoolHookTest extends AbstractStreamTest {
 
     @Test
     public void newStreamHookExists() {
@@ -60,7 +54,7 @@ public class LocalPoolHookTest {
         TestSubscriber<StreamId<?>> subscriber = new TestSubscriber<>();
         Flowable.fromPublisher(newStreamHook()).take(1).subscribe(subscriber);
 
-        pool.provide(anyStreamId, mock(Publisher.class));
+        provide(mock(Publisher.class)).as(anyStreamId);
 
         subscriber.awaitTerminalEvent(2, SECONDS);
         subscriber.assertValues(anyStreamId);
@@ -76,7 +70,7 @@ public class LocalPoolHookTest {
     }
 
     private Publisher<StreamId<?>> newStreamHook() {
-        return pool.discover(NEW_STREAM_HOOK);
+        return discover(NEW_STREAM_HOOK);
     }
 
 }

--- a/src/test/org/streamingpool/core/service/impl/LocalPoolSingleThreadingTest.java
+++ b/src/test/org/streamingpool/core/service/impl/LocalPoolSingleThreadingTest.java
@@ -15,24 +15,22 @@ import org.streamingpool.core.testing.AbstractStreamTest;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class LocalPoolSingleThreadingTest extends AbstractStreamTest implements RxStreamSupport {
 
-    public LocalPoolSingleThreadingTest(){
+    public LocalPoolSingleThreadingTest() {
         System.setProperty(STREAMINGPOOL_THREAD_POOL_SIZE, "1");
     }
 
     @Test(expected = LocalPoolSingleThreadingTestException.class)
     public void shouldObserveOnASingleThread() {
-        Flowable<Long> source = Flowable.just(1L, 2L, 3L, 4L)
-                .share()
-                .onBackpressureLatest();
+        Flowable<Long> source = Flowable.just(1L, 2L, 3L, 4L).share().onBackpressureLatest();
         StreamId<Long> streamId = provide(source).withUniqueStreamId();
         rxFrom(streamId).subscribe(i -> SECONDS.sleep(10));
-        rxFrom(streamId).test().awaitCount(2, () ->  {throw new LocalPoolSingleThreadingTestException();}, 100);
+        rxFrom(streamId).test().awaitCount(2, () -> {
+            throw new LocalPoolSingleThreadingTestException();
+        } , 100);
     }
 
-    private static class LocalPoolSingleThreadingTestException extends RuntimeException{
-
+    private static class LocalPoolSingleThreadingTestException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
     }
-
-
 
 }

--- a/src/test/org/streamingpool/core/service/impl/LocalPoolSingleThreadingTest.java
+++ b/src/test/org/streamingpool/core/service/impl/LocalPoolSingleThreadingTest.java
@@ -1,0 +1,38 @@
+package org.streamingpool.core.service.impl;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.streamingpool.core.conf.DefaultSchedulerConfiguration.STREAMINGPOOL_THREAD_POOL_SIZE;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.reactivex.Flowable;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.streamingpool.core.service.StreamId;
+import org.streamingpool.core.support.RxStreamSupport;
+import org.streamingpool.core.testing.AbstractStreamTest;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class LocalPoolSingleThreadingTest extends AbstractStreamTest implements RxStreamSupport {
+
+    public LocalPoolSingleThreadingTest(){
+        System.setProperty(STREAMINGPOOL_THREAD_POOL_SIZE, "1");
+    }
+
+    @Test(expected = LocalPoolSingleThreadingTestException.class)
+    public void shouldObserveOnASingleThread() {
+        Flowable<Long> source = Flowable.just(1L, 2L, 3L, 4L)
+                .share()
+                .onBackpressureLatest();
+        StreamId<Long> streamId = provide(source).withUniqueStreamId();
+        rxFrom(streamId).subscribe(i -> SECONDS.sleep(10));
+        rxFrom(streamId).test().awaitCount(2, () ->  {throw new LocalPoolSingleThreadingTestException();}, 100);
+    }
+
+    private static class LocalPoolSingleThreadingTestException extends RuntimeException{
+
+    }
+
+
+
+}

--- a/src/test/org/streamingpool/core/service/impl/LocalPoolTest.java
+++ b/src/test/org/streamingpool/core/service/impl/LocalPoolTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import org.reactivestreams.Publisher;
 import org.streamingpool.core.service.StreamId;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.Executors;
 
@@ -47,7 +46,6 @@ public class LocalPoolTest {
     private static final StreamId<Object> ID_B = mock(StreamId.class);
     private static final StreamId<Object> ID_NOT_PROVIDED = mock(StreamId.class);
     private static final Publisher<Object> STREAM_A = mock(Publisher.class);
-    private static final Publisher<Object> STREAM_B = mock(Publisher.class);
 
     private LocalPool pool;
 

--- a/src/test/org/streamingpool/core/service/impl/LocalPoolTest.java
+++ b/src/test/org/streamingpool/core/service/impl/LocalPoolTest.java
@@ -22,11 +22,11 @@
 
 package org.streamingpool.core.service.impl;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.reactivestreams.Publisher;
 import org.streamingpool.core.service.StreamId;
 
@@ -67,13 +67,6 @@ public class LocalPoolTest {
         pool.provide(ID_A, STREAM_A);
     }
 
-    @Test
-    public void provideNewSupplier() {
-        pool.provide(ID_B, STREAM_B);
-        Publisher<Object> stream = pool.discover(ID_B);
-
-        assertEquals(STREAM_B, stream);
-    }
 
     @Test(expected = NullPointerException.class)
     public void discoverNullId() {
@@ -83,13 +76,6 @@ public class LocalPoolTest {
     @Test(expected = IllegalArgumentException.class)
     public void discoverUnavailableStream() {
         pool.discover(ID_B);
-    }
-
-    @Test
-    public void discoverAvailableStream() {
-        Publisher<Object> stream = pool.discover(ID_A);
-
-        assertEquals(STREAM_A, stream);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/org/streamingpool/core/service/impl/LocalPoolTest.java
+++ b/src/test/org/streamingpool/core/service/impl/LocalPoolTest.java
@@ -24,11 +24,16 @@ package org.streamingpool.core.service.impl;
 
 import static org.mockito.Mockito.mock;
 
+import io.reactivex.schedulers.Schedulers;
 import org.junit.Before;
 import org.junit.Test;
 
 import org.reactivestreams.Publisher;
 import org.streamingpool.core.service.StreamId;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.Executors;
 
 /**
  * Standard unit tests covering {@link LocalPool}
@@ -48,7 +53,7 @@ public class LocalPoolTest {
 
     @Before
     public void setUp() {
-        pool = new LocalPool();
+        pool = new LocalPool(Collections.emptyList(), Schedulers.from(Executors.newSingleThreadExecutor()));
         pool.provide(ID_A, STREAM_A);
     }
 

--- a/src/test/org/streamingpool/core/service/impl/LocalPoolThreadingTest.java
+++ b/src/test/org/streamingpool/core/service/impl/LocalPoolThreadingTest.java
@@ -20,7 +20,7 @@ public class LocalPoolThreadingTest extends AbstractStreamTest implements RxStre
     }
 
     @Test(timeout = 500)
-    public void shouldObserveOnThreadPool() throws InterruptedException {
+    public void shouldObserveOnThreadPool() {
         Flowable<Long> source = Flowable.just(1L, 2L, 3L, 4L)
                 .share()
                 .onBackpressureLatest();

--- a/src/test/org/streamingpool/core/service/impl/LocalPoolThreadingTest.java
+++ b/src/test/org/streamingpool/core/service/impl/LocalPoolThreadingTest.java
@@ -1,0 +1,38 @@
+package org.streamingpool.core.service.impl;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.streamingpool.core.conf.DefaultSchedulerConfiguration.STREAMINGPOOL_THREAD_POOL_SIZE;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.reactivex.Flowable;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.streamingpool.core.service.StreamId;
+import org.streamingpool.core.support.RxStreamSupport;
+import org.streamingpool.core.testing.AbstractStreamTest;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class LocalPoolThreadingTest extends AbstractStreamTest implements RxStreamSupport {
+
+    public LocalPoolThreadingTest(){
+        System.setProperty(STREAMINGPOOL_THREAD_POOL_SIZE, "10");
+    }
+
+    @Test(timeout = 500)
+    public void shouldObserveOnThreadPool() throws InterruptedException {
+        Flowable<Long> source = Flowable.just(1L, 2L, 3L, 4L)
+                .share()
+                .onBackpressureLatest();
+
+        StreamId<Long> streamId = provide(source).withUniqueStreamId();
+        Flowable<Long> stream = rxFrom(streamId);
+        stream.subscribe(i -> SECONDS.sleep(10));
+        stream.test().awaitCount(4).assertValueAt(1, v -> 4 == v.intValue());
+    }
+
+
+
+
+
+}

--- a/src/test/org/streamingpool/core/service/stream/CombineWithLatestStreamIdStreamTest.java
+++ b/src/test/org/streamingpool/core/service/stream/CombineWithLatestStreamIdStreamTest.java
@@ -27,21 +27,23 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+
+import io.reactivex.Flowable;
+import io.reactivex.subscribers.TestSubscriber;
 import org.streamingpool.core.service.StreamId;
 import org.streamingpool.core.service.streamfactory.CombineWithLatestStreamFactory;
 import org.streamingpool.core.service.streamid.CombineWithLatestStreamId;
 import org.streamingpool.core.support.RxStreamSupport;
 import org.streamingpool.core.testing.AbstractStreamTest;
 
-import io.reactivex.Flowable;
-import io.reactivex.subscribers.TestSubscriber;
-
 /**
  * Unit tests for {@link CombineWithLatestStreamFactory}
  * 
  * @author acalia
  */
+@Ignore // bug will be fixed in RxJava 2.2
 public class CombineWithLatestStreamIdStreamTest extends AbstractStreamTest implements RxStreamSupport {
 
     private TestSubscriber<Long> subscriber;

--- a/src/test/org/streamingpool/core/service/stream/CombineWithLatestStreamIdStreamTest.java
+++ b/src/test/org/streamingpool/core/service/stream/CombineWithLatestStreamIdStreamTest.java
@@ -27,7 +27,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import io.reactivex.Flowable;
@@ -43,7 +42,6 @@ import org.streamingpool.core.testing.AbstractStreamTest;
  * 
  * @author acalia
  */
-@Ignore // bug will be fixed in RxJava 2.2
 public class CombineWithLatestStreamIdStreamTest extends AbstractStreamTest implements RxStreamSupport {
 
     private TestSubscriber<Long> subscriber;

--- a/src/test/org/streamingpool/core/service/stream/CreatorStreamTest.java
+++ b/src/test/org/streamingpool/core/service/stream/CreatorStreamTest.java
@@ -27,7 +27,9 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
+import java.util.concurrent.Executors;
 
+import io.reactivex.schedulers.Schedulers;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import org.streamingpool.core.service.CycleInStreamDiscoveryDetectedException;
@@ -57,11 +59,11 @@ public class CreatorStreamTest {
     private final IdentifiedStreamCreator<Object> creator = ImmutableIdentifiedStreamCreator.of(ID_A,
             discovery -> STREAM_A);
     private final CreatorStreamFactory factory = new CreatorStreamFactory(Arrays.asList(creator));
-    private final DiscoveryService discoveryService = new LocalPool(Arrays.asList(factory));
+    private final DiscoveryService discoveryService = new LocalPool(Arrays.asList(factory), Schedulers.from(Executors.newSingleThreadExecutor()));
 
     @Test(expected = CycleInStreamDiscoveryDetectedException.class)
     public void testCycleLoopDetectedUsingStreamCreators() {
-        DiscoveryService loopingDiscoveryService = new LocalPool(Arrays.asList(createLoopCreatorStreamFactory()));
+        DiscoveryService loopingDiscoveryService = new LocalPool(Arrays.asList(createLoopCreatorStreamFactory()), Schedulers.from(Executors.newSingleThreadExecutor()));
 
         loopingDiscoveryService.discover(ID_A);
     }

--- a/src/test/org/streamingpool/core/service/stream/OverlapBufferStreamTest.java
+++ b/src/test/org/streamingpool/core/service/stream/OverlapBufferStreamTest.java
@@ -90,7 +90,7 @@ public class OverlapBufferStreamTest {
     }
 
     @Test
-    public void dataStreamEndsBeforeEndStreamEmitsShouldBufferEverything() throws InterruptedException {
+    public void dataStreamEndsBeforeEndStreamEmitsShouldBufferEverything() {
         StreamId<Long> sourceId = registerRx(interval(1, SECONDS, testScheduler).take(5));
         StreamId<Object> startId = registerRx(merge(just(new Object()).delay(2, SECONDS, testScheduler), never()));
         StreamId<Object> endId = registerRx(never());

--- a/src/test/org/streamingpool/core/service/streamfactory/OverlapBufferStreamFactoryTest.java
+++ b/src/test/org/streamingpool/core/service/streamfactory/OverlapBufferStreamFactoryTest.java
@@ -55,8 +55,8 @@ public class OverlapBufferStreamFactoryTest extends AbstractStreamTest implement
     private OverlapBufferStreamFactory overlapBufferStreamFactory;
 
     /**
-     * This test ensures that the first element of the source stream is not ignored,
-     * and that the correct amount of values are buffered.
+     * This test ensures that the first element of the source stream is not ignored, and that the correct amount of
+     * values are buffered.
      */
     @Test
     public void testBufferWithInterval() {
@@ -69,9 +69,9 @@ public class OverlapBufferStreamFactoryTest extends AbstractStreamTest implement
         StreamId<Long> sourceId = Mockito.mock(StreamId.class);
         StreamId<Long> startStreamId = Mockito.mock(StreamId.class);
         StreamId<Long> endStreamId = Mockito.mock(StreamId.class);
-        EndStreamMatcher endStreamMatcher = EndStreamMatcher.endingOnEvery(endStreamId);
+        EndStreamMatcher<?, ?> endStreamMatcher = EndStreamMatcher.endingOnEvery(endStreamId);
         BufferSpecification bufferSpecification = ofStartEnd(startStreamId, singleton(endStreamMatcher));
-        OverlapBufferStreamId streamId = OverlapBufferStreamId.of(sourceId, bufferSpecification);
+        OverlapBufferStreamId<?> streamId = OverlapBufferStreamId.of(sourceId, bufferSpecification);
 
         when(discoveryService.discover(sourceId)).thenReturn(source);
         when(discoveryService.discover(startStreamId)).thenReturn(start);


### PR DESCRIPTION
This should prevent slow clients impacting fast ones.
(and introduces a lot of funny side effects :))
Added a TestSchedulerConfiguration class to run the ObserveOn on a TestScheduler for unit testing purpose.
Use Reactor Flux for CombineWithLatestStreamFactory until the bug is fixed in RxJava release 2.2
