### PR TITLE
FanOutStreamId

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,11 +71,6 @@ sourceCompatibility = 1.8
 dependencies {
     compile 'org.reactivestreams:reactive-streams:1.0.0'
     compile 'io.reactivex.rxjava2:rxjava:2.1.+'
-    compile group: 'io.projectreactor', name: 'reactor-core', version: '3.0.7.RELEASE'
-    //compile 'com.typesafe.akka:akka-stream_2.11:2.4.16'
-
-    //compile group: 'com.typesafe.akka', name: 'akka-stream_2.11', version:'2.5.3'
-    //testCompile group: 'com.typesafe.akka', name: 'akka-stream-testkit_2.11', version:'2.5.3'
 
     compile 'org.springframework:spring-core:4.3.9.RELEASE'
     compile 'org.springframework:spring-context:4.3.9.RELEASE'

--- a/src/java/org/streamingpool/core/conf/DefaultPoolConfiguration.java
+++ b/src/java/org/streamingpool/core/conf/DefaultPoolConfiguration.java
@@ -23,11 +23,10 @@
 package org.streamingpool.core.conf;
 
 import static java.util.Arrays.stream;
-import static org.streamingpool.core.conf.TestSchedulerConfiguration.STREAMINGPOOL_TEST_SCHEDULER;
+import static org.streamingpool.core.conf.TestPoolConfiguration.STREAMINGPOOL_TEST_SCHEDULER;
 
 import java.util.concurrent.Executors;
 
-import io.reactivex.Scheduler;
 import io.reactivex.schedulers.Schedulers;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -39,18 +38,21 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 @Configuration
-public class DefaultSchedulerConfiguration {
+public class DefaultPoolConfiguration {
 
     public static final String STREAMINGPOOL_THREAD_POOL_SIZE = "streamingpool.threadPoolSize";
-
+    public static final String STREAMINGPOOL_OBSERVE_ON_CAPACITY = "streamingpool.observeOnCapacity";
 
     @Value("${" + STREAMINGPOOL_THREAD_POOL_SIZE + ":100}")
     private int threadPoolSize;
 
+    @Value("${" + STREAMINGPOOL_OBSERVE_ON_CAPACITY + ":128}")
+    private int observeOnCapacity;
+
     @Bean
     @Conditional(NoTestSchedulerPresent.class)
-    public Scheduler scheduler(){
-        return Schedulers.from(Executors.newFixedThreadPool(threadPoolSize));
+    public PoolConfiguration localPoolConfiguration() {
+        return new PoolConfiguration(Schedulers.from(Executors.newFixedThreadPool(threadPoolSize)), observeOnCapacity);
     }
 
     private static class NoTestSchedulerPresent implements Condition {
@@ -61,6 +63,5 @@ public class DefaultSchedulerConfiguration {
             return !stream(env.getActiveProfiles()).anyMatch(STREAMINGPOOL_TEST_SCHEDULER::equals);
         }
     }
-
 
 }

--- a/src/java/org/streamingpool/core/conf/EmbeddedPoolConfiguration.java
+++ b/src/java/org/streamingpool/core/conf/EmbeddedPoolConfiguration.java
@@ -26,7 +26,6 @@ import static org.streamingpool.core.util.MoreCollections.emptyIfNull;
 
 import java.util.List;
 
-import io.reactivex.Scheduler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -48,7 +47,7 @@ import org.streamingpool.core.service.impl.LocalPool;
  * @author kfuchsbe
  */
 @Configuration
-@Import({TestSchedulerConfiguration.class, DefaultSchedulerConfiguration.class})
+@Import({ TestPoolConfiguration.class, DefaultPoolConfiguration.class})
 public class EmbeddedPoolConfiguration {
 
     /**
@@ -59,11 +58,11 @@ public class EmbeddedPoolConfiguration {
     private List<StreamFactory> streamFactories;
 
     @Autowired
-    private Scheduler scheduler;
+    private PoolConfiguration poolConfiguration;
 
     @Bean
     public LocalPool pool() {
-        return new LocalPool(emptyIfNull(streamFactories), scheduler);
+        return new LocalPool(emptyIfNull(streamFactories), poolConfiguration);
     }
 
 }

--- a/src/java/org/streamingpool/core/conf/PoolConfiguration.java
+++ b/src/java/org/streamingpool/core/conf/PoolConfiguration.java
@@ -1,0 +1,29 @@
+package org.streamingpool.core.conf;
+
+import io.reactivex.Scheduler;
+
+/**
+ * @author mgabriel.
+ */
+public class PoolConfiguration {
+
+    private final Scheduler scheduler;
+    private final int observeOnCapacity;
+
+    public PoolConfiguration(Scheduler scheduler) {
+        this(scheduler, 128);
+    }
+
+    public PoolConfiguration(Scheduler scheduler, int observeOnCapacity) {
+        this.scheduler = scheduler;
+        this.observeOnCapacity = observeOnCapacity;
+    }
+
+    public Scheduler getScheduler() {
+        return scheduler;
+    }
+
+    public int getObserveOnCapacity() {
+        return observeOnCapacity;
+    }
+}

--- a/src/java/org/streamingpool/core/conf/TestPoolConfiguration.java
+++ b/src/java/org/streamingpool/core/conf/TestPoolConfiguration.java
@@ -28,14 +28,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile(TestSchedulerConfiguration.STREAMINGPOOL_TEST_SCHEDULER)
-public class TestSchedulerConfiguration {
+@Profile(TestPoolConfiguration.STREAMINGPOOL_TEST_SCHEDULER)
+public class TestPoolConfiguration {
 
     public static final String STREAMINGPOOL_TEST_SCHEDULER = "streamingpool.test.scheduler";
 
     @Bean
-    public TestScheduler scheduler(){
-        return new TestScheduler();
+    public PoolConfiguration localPoolConfiguration(){
+        return new PoolConfiguration(new TestScheduler(), 128);
     }
 
 

--- a/src/java/org/streamingpool/core/domain/backpressure/BackpressureAware.java
+++ b/src/java/org/streamingpool/core/domain/backpressure/BackpressureAware.java
@@ -1,0 +1,7 @@
+package org.streamingpool.core.domain.backpressure;
+
+
+public interface BackpressureAware {
+
+    BackpressureStrategy backpressureStrategy();
+}

--- a/src/java/org/streamingpool/core/domain/backpressure/BackpressureBufferStrategy.java
+++ b/src/java/org/streamingpool/core/domain/backpressure/BackpressureBufferStrategy.java
@@ -1,0 +1,54 @@
+package org.streamingpool.core.domain.backpressure;
+
+public class BackpressureBufferStrategy implements BackpressureStrategy {
+
+    private final int bufferSize;
+    private final BackpressureBufferOverflowStrategy overflowStrategy;
+
+    /**
+     * Package protected, create using {@link BackpressureStrategies} utility class.
+     */
+    BackpressureBufferStrategy(int bufferSize, BackpressureBufferOverflowStrategy overflowStrategy) {
+        this.bufferSize = bufferSize;
+        this.overflowStrategy = overflowStrategy;
+    }
+
+    public int bufferSize() {
+        return bufferSize;
+    }
+
+    public BackpressureBufferOverflowStrategy overflowStrategy() {
+        return overflowStrategy;
+    }
+
+    public enum BackpressureBufferOverflowStrategy {
+        DROP_LATEST,
+        DROP_OLDEST;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BackpressureBufferStrategy that = (BackpressureBufferStrategy) o;
+
+        if (bufferSize != that.bufferSize) return false;
+        return overflowStrategy == that.overflowStrategy;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = bufferSize;
+        result = 31 * result + (overflowStrategy != null ? overflowStrategy.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "BackpressureBufferStrategy[" +
+            "bufferSize=" + bufferSize +
+            ", overflowStrategy=" + overflowStrategy +
+            ']';
+    }
+}

--- a/src/java/org/streamingpool/core/domain/backpressure/BackpressureDropStrategy.java
+++ b/src/java/org/streamingpool/core/domain/backpressure/BackpressureDropStrategy.java
@@ -1,0 +1,4 @@
+package org.streamingpool.core.domain.backpressure;
+
+public class BackpressureDropStrategy implements BackpressureStrategy {
+}

--- a/src/java/org/streamingpool/core/domain/backpressure/BackpressureLatestStrategy.java
+++ b/src/java/org/streamingpool/core/domain/backpressure/BackpressureLatestStrategy.java
@@ -1,0 +1,4 @@
+package org.streamingpool.core.domain.backpressure;
+
+public class BackpressureLatestStrategy implements BackpressureStrategy {
+}

--- a/src/java/org/streamingpool/core/domain/backpressure/BackpressureNoneStrategy.java
+++ b/src/java/org/streamingpool/core/domain/backpressure/BackpressureNoneStrategy.java
@@ -1,0 +1,4 @@
+package org.streamingpool.core.domain.backpressure;
+
+public class BackpressureNoneStrategy implements BackpressureStrategy {
+}

--- a/src/java/org/streamingpool/core/domain/backpressure/BackpressureStrategies.java
+++ b/src/java/org/streamingpool/core/domain/backpressure/BackpressureStrategies.java
@@ -1,0 +1,38 @@
+package org.streamingpool.core.domain.backpressure;
+
+import org.streamingpool.core.domain.backpressure.BackpressureBufferStrategy.BackpressureBufferOverflowStrategy;
+
+public final class BackpressureStrategies {
+
+    public static final BackpressureBufferOverflowStrategy DEFAULT_BUFFER_OVERFLOW_STRATEGY = BackpressureBufferOverflowStrategy.DROP_LATEST;
+    public static final int DEFAULT_BUFFER_SIZE = 100;
+
+    private BackpressureStrategies() {
+        /* static methods */
+    }
+
+    public static BackpressureStrategy onBackpressureBuffer() {
+        return new BackpressureBufferStrategy(DEFAULT_BUFFER_SIZE, DEFAULT_BUFFER_OVERFLOW_STRATEGY);
+    }
+
+    public static BackpressureStrategy onBackpressureBuffer(int bufferSize) {
+        return new BackpressureBufferStrategy(bufferSize, DEFAULT_BUFFER_OVERFLOW_STRATEGY);
+    }
+
+    public static BackpressureStrategy onBackpressureBuffer(int bufferSize, BackpressureBufferOverflowStrategy overflowStrategy) {
+        return new BackpressureBufferStrategy(bufferSize, overflowStrategy);
+    }
+
+    public static BackpressureStrategy onBackpressureDrop() {
+        return new BackpressureDropStrategy();
+    }
+
+    public static BackpressureStrategy onBackpressureLatest() {
+        return new BackpressureLatestStrategy();
+    }
+
+    public static BackpressureStrategy defaultBackpressureStrategy() {
+        return onBackpressureLatest();
+    }
+
+}

--- a/src/java/org/streamingpool/core/domain/backpressure/BackpressureStrategies.java
+++ b/src/java/org/streamingpool/core/domain/backpressure/BackpressureStrategies.java
@@ -6,13 +6,17 @@ public final class BackpressureStrategies {
 
     public static final BackpressureBufferOverflowStrategy DEFAULT_BUFFER_OVERFLOW_STRATEGY = BackpressureBufferOverflowStrategy.DROP_LATEST;
     public static final int DEFAULT_BUFFER_SIZE = 100;
+    private static final BackpressureBufferStrategy DEFAULT_BUFFER_STRATEGY = new BackpressureBufferStrategy(DEFAULT_BUFFER_SIZE, DEFAULT_BUFFER_OVERFLOW_STRATEGY);
+    private static final BackpressureNoneStrategy BACKPRESSURE_NONE_STRATEGY = new BackpressureNoneStrategy();
+    private static final BackpressureLatestStrategy BACKPRESSURE_LATEST_STRATEGY = new BackpressureLatestStrategy();
+    private static final BackpressureDropStrategy BACKPRESSURE_DROP_STRATEGY = new BackpressureDropStrategy();
 
     private BackpressureStrategies() {
         /* static methods */
     }
 
     public static BackpressureStrategy onBackpressureBuffer() {
-        return new BackpressureBufferStrategy(DEFAULT_BUFFER_SIZE, DEFAULT_BUFFER_OVERFLOW_STRATEGY);
+        return DEFAULT_BUFFER_STRATEGY;
     }
 
     public static BackpressureStrategy onBackpressureBuffer(int bufferSize) {
@@ -24,15 +28,19 @@ public final class BackpressureStrategies {
     }
 
     public static BackpressureStrategy onBackpressureDrop() {
-        return new BackpressureDropStrategy();
+        return BACKPRESSURE_DROP_STRATEGY;
     }
 
     public static BackpressureStrategy onBackpressureLatest() {
-        return new BackpressureLatestStrategy();
+        return BACKPRESSURE_LATEST_STRATEGY;
     }
 
     public static BackpressureStrategy defaultBackpressureStrategy() {
         return onBackpressureLatest();
+    }
+
+    public static BackpressureStrategy none() {
+        return BACKPRESSURE_NONE_STRATEGY;
     }
 
 }

--- a/src/java/org/streamingpool/core/domain/backpressure/BackpressureStrategy.java
+++ b/src/java/org/streamingpool/core/domain/backpressure/BackpressureStrategy.java
@@ -1,0 +1,4 @@
+package org.streamingpool.core.domain.backpressure;
+
+public interface BackpressureStrategy {
+}

--- a/src/java/org/streamingpool/core/service/impl/LocalPool.java
+++ b/src/java/org/streamingpool/core/service/impl/LocalPool.java
@@ -27,9 +27,11 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.reactivestreams.Publisher;
+import org.streamingpool.core.conf.PoolConfiguration;
 import org.streamingpool.core.domain.ErrorStreamPair;
 import org.streamingpool.core.service.DiscoveryService;
 import org.streamingpool.core.service.ProvidingService;
@@ -37,8 +39,6 @@ import org.streamingpool.core.service.StreamFactory;
 import org.streamingpool.core.service.StreamFactoryRegistry;
 import org.streamingpool.core.service.StreamId;
 import org.streamingpool.core.service.TypedStreamFactory;
-
-import io.reactivex.Scheduler;
 
 /**
  * Local pool for providing and discovery of {@link Publisher}s. (this class is both a {@link DiscoveryService} and a
@@ -52,15 +52,15 @@ public class LocalPool implements DiscoveryService, ProvidingService, StreamFact
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LocalPool.class);
 
-    private final Scheduler scheduler;
+    private final PoolConfiguration poolConfiguration;
     private final List<StreamFactory> factories;
     private final PoolContent content = new PoolContent();
 
-    public LocalPool(List<StreamFactory> factories, Scheduler scheduler) {
+    public LocalPool(List<StreamFactory> factories, PoolConfiguration poolConfiguration) {
         requireNonNull(factories,"Factories can not be null");
         this.factories = new CopyOnWriteArrayList<>(factories);
         LOGGER.info("Available Stream Factories: {}", factories);
-        this.scheduler = scheduler;
+        this.poolConfiguration = poolConfiguration;
     }
 
     @Override
@@ -77,7 +77,7 @@ public class LocalPool implements DiscoveryService, ProvidingService, StreamFact
     @Override
     public <T> Publisher<T> discover(StreamId<T> id) {
         requireNonNull(id, "Cannot discover a null id");
-        return new TrackKeepingDiscoveryService(factories, content, scheduler).discover(id);
+        return new TrackKeepingDiscoveryService(factories, content, poolConfiguration).discover(id);
     }
 
     @Override

--- a/src/java/org/streamingpool/core/service/impl/TrackKeepingDiscoveryService.java
+++ b/src/java/org/streamingpool/core/service/impl/TrackKeepingDiscoveryService.java
@@ -30,6 +30,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import io.reactivex.BackpressureOverflowStrategy;
+import io.reactivex.BackpressureStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +85,12 @@ public class TrackKeepingDiscoveryService implements DiscoveryService {
 
     private <T> Publisher<T> applyBackpressure(Publisher<T> publisher) {
         return Flowable.fromPublisher(publisher)
-                .observeOn(scheduler, false, 1);
+                .onBackpressureBuffer(1, ()-> System.out.println("dropped"), BackpressureOverflowStrategy.DROP_OLDEST )
+                .observeOn(scheduler, false, 128)
+
+
+                .onBackpressureBuffer(1, ()-> System.out.println("dropped"), BackpressureOverflowStrategy.DROP_OLDEST )
+            ;
     }
 
     private <T> Publisher<T> getStreamWithIdOrElseThrow(StreamId<T> id) {

--- a/src/java/org/streamingpool/core/service/streamfactory/CombineWithLatestStreamFactory.java
+++ b/src/java/org/streamingpool/core/service/streamfactory/CombineWithLatestStreamFactory.java
@@ -29,7 +29,7 @@ import org.streamingpool.core.service.DiscoveryService;
 import org.streamingpool.core.service.StreamFactory;
 import org.streamingpool.core.service.StreamId;
 import org.streamingpool.core.service.streamid.CombineWithLatestStreamId;
-import reactor.core.publisher.Flux;
+
 
 /**
  * Factory for {@link CombineWithLatestStreamId}
@@ -54,8 +54,7 @@ public class CombineWithLatestStreamFactory implements StreamFactory {
         Flowable<D> data = Flowable.fromPublisher(discoveryService.discover(streamId.dataStream()));
         Flowable<T> trigger = Flowable.fromPublisher(discoveryService.discover(streamId.triggerStream()));
 
-        /* TODO remove the Flux once RxJava2 has been released with the bug fix (version 2.2) */
-        return Flux.from(trigger).withLatestFrom(data, streamId.combiner()::apply);
+        return trigger.withLatestFrom(data, streamId.combiner()::apply);
     }
 
 }

--- a/src/java/org/streamingpool/core/service/streamfactory/FanOutStreamFactory.java
+++ b/src/java/org/streamingpool/core/service/streamfactory/FanOutStreamFactory.java
@@ -35,19 +35,19 @@ public class FanOutStreamFactory implements StreamFactory {
         Flowable<T> targetStream = Flowable.fromPublisher(discoveryService.discover(fanOutId.target())).share();
 
         if (backpressureStrategy instanceof BackpressureLatestStrategy) {
-            return ofData(targetStream.onBackpressureLatest());
+            return ed.stream(targetStream.onBackpressureLatest());
         }
         if (backpressureStrategy instanceof BackpressureDropStrategy) {
-            return ofData(targetStream.onBackpressureDrop());
+            return ed.stream(targetStream.onBackpressureDrop(v -> System.out.println(Thread.currentThread().getName() + " Droppped " +v)));
         }
         if (backpressureStrategy instanceof BackpressureBufferStrategy) {
             BackpressureBufferStrategy bufferStrategy = (BackpressureBufferStrategy) backpressureStrategy;
 
             if (bufferStrategy.overflowStrategy() == BackpressureBufferOverflowStrategy.DROP_LATEST) {
-                return ofData(targetStream.onBackpressureBuffer(bufferStrategy.bufferSize(), NOOP, BackpressureOverflowStrategy.DROP_LATEST));
+                return ed.stream(targetStream.onBackpressureBuffer(bufferStrategy.bufferSize(), NOOP, BackpressureOverflowStrategy.DROP_LATEST));
             }
             if (bufferStrategy.overflowStrategy() == BackpressureBufferOverflowStrategy.DROP_OLDEST) {
-                return ofData(targetStream.onBackpressureBuffer(bufferStrategy.bufferSize(), NOOP, BackpressureOverflowStrategy.DROP_OLDEST));
+                return ed.stream(targetStream.onBackpressureBuffer(bufferStrategy.bufferSize(), NOOP, BackpressureOverflowStrategy.DROP_OLDEST));
             }
 
             throw new IllegalArgumentException("Cannot determine the specified buffer overflow strategy: " + bufferStrategy);

--- a/src/java/org/streamingpool/core/service/streamfactory/FanOutStreamFactory.java
+++ b/src/java/org/streamingpool/core/service/streamfactory/FanOutStreamFactory.java
@@ -1,25 +1,14 @@
 package org.streamingpool.core.service.streamfactory;
 
-import io.reactivex.BackpressureOverflowStrategy;
 import io.reactivex.Flowable;
-import io.reactivex.functions.Action;
 import org.streamingpool.core.domain.ErrorDeflector;
 import org.streamingpool.core.domain.ErrorStreamPair;
-import org.streamingpool.core.domain.backpressure.BackpressureBufferStrategy;
-import org.streamingpool.core.domain.backpressure.BackpressureBufferStrategy.BackpressureBufferOverflowStrategy;
-import org.streamingpool.core.domain.backpressure.BackpressureDropStrategy;
-import org.streamingpool.core.domain.backpressure.BackpressureLatestStrategy;
-import org.streamingpool.core.domain.backpressure.BackpressureStrategy;
 import org.streamingpool.core.service.DiscoveryService;
 import org.streamingpool.core.service.StreamFactory;
 import org.streamingpool.core.service.StreamId;
 import org.streamingpool.core.service.streamid.FanOutStreamId;
 
-import static org.streamingpool.core.domain.ErrorStreamPair.ofData;
-
 public class FanOutStreamFactory implements StreamFactory {
-
-    private final Action NOOP = () -> {};
 
     @Override
     public <T> ErrorStreamPair<T> create(StreamId<T> id, DiscoveryService discoveryService) {
@@ -28,31 +17,10 @@ public class FanOutStreamFactory implements StreamFactory {
         }
 
         FanOutStreamId<T> fanOutId = (FanOutStreamId<T>) id;
-        BackpressureStrategy backpressureStrategy = fanOutId.backpressureStrategy();
 
         ErrorDeflector ed = ErrorDeflector.create();
 
         Flowable<T> targetStream = Flowable.fromPublisher(discoveryService.discover(fanOutId.target())).share();
-
-        if (backpressureStrategy instanceof BackpressureLatestStrategy) {
-            return ed.stream(targetStream.onBackpressureLatest());
-        }
-        if (backpressureStrategy instanceof BackpressureDropStrategy) {
-            return ed.stream(targetStream.onBackpressureDrop(v -> System.out.println(Thread.currentThread().getName() + " Droppped " +v)));
-        }
-        if (backpressureStrategy instanceof BackpressureBufferStrategy) {
-            BackpressureBufferStrategy bufferStrategy = (BackpressureBufferStrategy) backpressureStrategy;
-
-            if (bufferStrategy.overflowStrategy() == BackpressureBufferOverflowStrategy.DROP_LATEST) {
-                return ed.stream(targetStream.onBackpressureBuffer(bufferStrategy.bufferSize(), NOOP, BackpressureOverflowStrategy.DROP_LATEST));
-            }
-            if (bufferStrategy.overflowStrategy() == BackpressureBufferOverflowStrategy.DROP_OLDEST) {
-                return ed.stream(targetStream.onBackpressureBuffer(bufferStrategy.bufferSize(), NOOP, BackpressureOverflowStrategy.DROP_OLDEST));
-            }
-
-            throw new IllegalArgumentException("Cannot determine the specified buffer overflow strategy: " + bufferStrategy);
-        }
-
-        throw new IllegalArgumentException("Cannot determine the specified backpressure strategy: " + backpressureStrategy);
+        return ed.stream(targetStream);
     }
 }

--- a/src/java/org/streamingpool/core/service/streamfactory/FanOutStreamFactory.java
+++ b/src/java/org/streamingpool/core/service/streamfactory/FanOutStreamFactory.java
@@ -1,0 +1,58 @@
+package org.streamingpool.core.service.streamfactory;
+
+import io.reactivex.BackpressureOverflowStrategy;
+import io.reactivex.Flowable;
+import io.reactivex.functions.Action;
+import org.streamingpool.core.domain.ErrorDeflector;
+import org.streamingpool.core.domain.ErrorStreamPair;
+import org.streamingpool.core.domain.backpressure.BackpressureBufferStrategy;
+import org.streamingpool.core.domain.backpressure.BackpressureBufferStrategy.BackpressureBufferOverflowStrategy;
+import org.streamingpool.core.domain.backpressure.BackpressureDropStrategy;
+import org.streamingpool.core.domain.backpressure.BackpressureLatestStrategy;
+import org.streamingpool.core.domain.backpressure.BackpressureStrategy;
+import org.streamingpool.core.service.DiscoveryService;
+import org.streamingpool.core.service.StreamFactory;
+import org.streamingpool.core.service.StreamId;
+import org.streamingpool.core.service.streamid.FanOutStreamId;
+
+import static org.streamingpool.core.domain.ErrorStreamPair.ofData;
+
+public class FanOutStreamFactory implements StreamFactory {
+
+    private final Action NOOP = () -> {};
+
+    @Override
+    public <T> ErrorStreamPair<T> create(StreamId<T> id, DiscoveryService discoveryService) {
+        if (!(id instanceof FanOutStreamId)) {
+            return ErrorStreamPair.empty();
+        }
+
+        FanOutStreamId<T> fanOutId = (FanOutStreamId<T>) id;
+        BackpressureStrategy backpressureStrategy = fanOutId.backpressureStrategy();
+
+        ErrorDeflector ed = ErrorDeflector.create();
+
+        Flowable<T> targetStream = Flowable.fromPublisher(discoveryService.discover(fanOutId.target())).share();
+
+        if (backpressureStrategy instanceof BackpressureLatestStrategy) {
+            return ofData(targetStream.onBackpressureLatest());
+        }
+        if (backpressureStrategy instanceof BackpressureDropStrategy) {
+            return ofData(targetStream.onBackpressureDrop());
+        }
+        if (backpressureStrategy instanceof BackpressureBufferStrategy) {
+            BackpressureBufferStrategy bufferStrategy = (BackpressureBufferStrategy) backpressureStrategy;
+
+            if (bufferStrategy.overflowStrategy() == BackpressureBufferOverflowStrategy.DROP_LATEST) {
+                return ofData(targetStream.onBackpressureBuffer(bufferStrategy.bufferSize(), NOOP, BackpressureOverflowStrategy.DROP_LATEST));
+            }
+            if (bufferStrategy.overflowStrategy() == BackpressureBufferOverflowStrategy.DROP_OLDEST) {
+                return ofData(targetStream.onBackpressureBuffer(bufferStrategy.bufferSize(), NOOP, BackpressureOverflowStrategy.DROP_OLDEST));
+            }
+
+            throw new IllegalArgumentException("Cannot determine the specified buffer overflow strategy: " + bufferStrategy);
+        }
+
+        throw new IllegalArgumentException("Cannot determine the specified backpressure strategy: " + backpressureStrategy);
+    }
+}

--- a/src/java/org/streamingpool/core/service/streamid/FanOutStreamId.java
+++ b/src/java/org/streamingpool/core/service/streamid/FanOutStreamId.java
@@ -1,0 +1,55 @@
+package org.streamingpool.core.service.streamid;
+
+import org.streamingpool.core.domain.backpressure.BackpressureStrategy;
+import org.streamingpool.core.service.StreamId;
+
+import static java.util.Objects.requireNonNull;
+import static org.streamingpool.core.domain.backpressure.BackpressureStrategies.defaultBackpressureStrategy;
+
+public class FanOutStreamId<T> implements StreamId<T> {
+
+    private final StreamId<T> target;
+    private final BackpressureStrategy backpressureStrategy;
+
+    private FanOutStreamId(StreamId<T> target, BackpressureStrategy backpressureStrategy) {
+        this.target = requireNonNull(target);
+        this.backpressureStrategy = requireNonNull(backpressureStrategy);
+    }
+
+    public static <T> FanOutStreamId<T> fanOut(StreamId<T> target, BackpressureStrategy backpressureStrategy) {
+        return new FanOutStreamId<T>(target, backpressureStrategy);
+    }
+    public static <T> FanOutStreamId<T> fanOut(StreamId<T> target) {
+        return new FanOutStreamId<T>(target, defaultBackpressureStrategy());
+    }
+
+    public StreamId<T> target() {
+        return target;
+    }
+
+    public BackpressureStrategy backpressureStrategy() {
+        return backpressureStrategy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FanOutStreamId<?> that = (FanOutStreamId<?>) o;
+
+        return target != null ? target.equals(that.target) : that.target == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return target != null ? target.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "FanOutStreamId[" +
+            "target=" + target +
+            ']';
+    }
+}

--- a/src/java/org/streamingpool/core/service/streamid/FanOutStreamId.java
+++ b/src/java/org/streamingpool/core/service/streamid/FanOutStreamId.java
@@ -1,12 +1,16 @@
 package org.streamingpool.core.service.streamid;
 
-import org.streamingpool.core.domain.backpressure.BackpressureStrategy;
-import org.streamingpool.core.service.StreamId;
-
 import static java.util.Objects.requireNonNull;
 import static org.streamingpool.core.domain.backpressure.BackpressureStrategies.defaultBackpressureStrategy;
 
-public class FanOutStreamId<T> implements StreamId<T> {
+import java.util.Objects;
+
+import org.streamingpool.core.domain.backpressure.BackpressureAware;
+import org.streamingpool.core.domain.backpressure.BackpressureStrategy;
+import org.streamingpool.core.service.StreamId;
+
+public class FanOutStreamId<T> implements StreamId<T>, BackpressureAware {
+    private static final long serialVersionUID = 1L;
 
     private final StreamId<T> target;
     private final BackpressureStrategy backpressureStrategy;
@@ -17,39 +21,42 @@ public class FanOutStreamId<T> implements StreamId<T> {
     }
 
     public static <T> FanOutStreamId<T> fanOut(StreamId<T> target, BackpressureStrategy backpressureStrategy) {
-        return new FanOutStreamId<T>(target, backpressureStrategy);
+        return new FanOutStreamId<>(target, backpressureStrategy);
     }
     public static <T> FanOutStreamId<T> fanOut(StreamId<T> target) {
-        return new FanOutStreamId<T>(target, defaultBackpressureStrategy());
+        return new FanOutStreamId<>(target, defaultBackpressureStrategy());
     }
 
     public StreamId<T> target() {
         return target;
     }
 
+    @Override
     public BackpressureStrategy backpressureStrategy() {
         return backpressureStrategy;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         FanOutStreamId<?> that = (FanOutStreamId<?>) o;
-
-        return target != null ? target.equals(that.target) : that.target == null;
+        return Objects.equals(target, that.target) &&
+                Objects.equals(backpressureStrategy, that.backpressureStrategy);
     }
 
     @Override
     public int hashCode() {
-        return target != null ? target.hashCode() : 0;
+        return Objects.hash(target, backpressureStrategy);
     }
 
     @Override
     public String toString() {
-        return "FanOutStreamId[" +
-            "target=" + target +
-            ']';
+        return "FanOutStreamId{" +
+                "target=" + target +
+                ", backpressureStrategy=" + backpressureStrategy +
+                '}';
     }
 }

--- a/src/test/org/streamingpool/core/service/DiscoveryTest.java
+++ b/src/test/org/streamingpool/core/service/DiscoveryTest.java
@@ -30,14 +30,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executors;
 
-import io.reactivex.schedulers.Schedulers;
-import org.assertj.core.util.Lists;
 import org.junit.Test;
-import org.reactivestreams.Publisher;
-import org.streamingpool.core.service.impl.LocalPool;
-import org.streamingpool.core.testing.StreamFactoryMock;
 
 import io.reactivex.Flowable;
+import io.reactivex.schedulers.Schedulers;
+import org.assertj.core.util.Lists;
+import org.reactivestreams.Publisher;
+import org.streamingpool.core.conf.PoolConfiguration;
+import org.streamingpool.core.service.impl.LocalPool;
+import org.streamingpool.core.testing.StreamFactoryMock;
 
 /**
  * Test for the discovery of Streams using {@link TypedStreamFactory} and {@link LocalPool}.
@@ -111,7 +112,7 @@ public class DiscoveryTest {
     }
 
     private DiscoveryService prepareDiscoveryService(final List<StreamFactory> factories) {
-        return new LocalPool(factories, Schedulers.from(Executors.newSingleThreadExecutor()));
+        return new LocalPool(factories, new PoolConfiguration(Schedulers.from(Executors.newSingleThreadExecutor())));
     }
 
     private List<String> toList(Publisher<String> result) {

--- a/src/test/org/streamingpool/core/service/impl/LocalPoolSingleThreadingTest.java
+++ b/src/test/org/streamingpool/core/service/impl/LocalPoolSingleThreadingTest.java
@@ -1,7 +1,7 @@
 package org.streamingpool.core.service.impl;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.streamingpool.core.conf.DefaultSchedulerConfiguration.STREAMINGPOOL_THREAD_POOL_SIZE;
+import static org.streamingpool.core.conf.DefaultPoolConfiguration.STREAMINGPOOL_THREAD_POOL_SIZE;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/org/streamingpool/core/service/impl/LocalPoolTest.java
+++ b/src/test/org/streamingpool/core/service/impl/LocalPoolTest.java
@@ -24,15 +24,16 @@ package org.streamingpool.core.service.impl;
 
 import static org.mockito.Mockito.mock;
 
-import io.reactivex.schedulers.Schedulers;
+import java.util.Collections;
+import java.util.concurrent.Executors;
+
 import org.junit.Before;
 import org.junit.Test;
 
+import io.reactivex.schedulers.Schedulers;
 import org.reactivestreams.Publisher;
+import org.streamingpool.core.conf.PoolConfiguration;
 import org.streamingpool.core.service.StreamId;
-
-import java.util.Collections;
-import java.util.concurrent.Executors;
 
 /**
  * Standard unit tests covering {@link LocalPool}
@@ -51,7 +52,7 @@ public class LocalPoolTest {
 
     @Before
     public void setUp() {
-        pool = new LocalPool(Collections.emptyList(), Schedulers.from(Executors.newSingleThreadExecutor()));
+        pool = new LocalPool(Collections.emptyList(), new PoolConfiguration(Schedulers.from(Executors.newSingleThreadExecutor())));
         pool.provide(ID_A, STREAM_A);
     }
 

--- a/src/test/org/streamingpool/core/service/impl/LocalPoolThreadingTest.java
+++ b/src/test/org/streamingpool/core/service/impl/LocalPoolThreadingTest.java
@@ -1,12 +1,14 @@
 package org.streamingpool.core.service.impl;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.streamingpool.core.conf.DefaultSchedulerConfiguration.STREAMINGPOOL_THREAD_POOL_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.streamingpool.core.conf.DefaultPoolConfiguration.STREAMINGPOOL_THREAD_POOL_SIZE;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import io.reactivex.Flowable;
+import io.reactivex.subscribers.TestSubscriber;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.streamingpool.core.service.StreamId;
 import org.streamingpool.core.support.RxStreamSupport;
@@ -28,11 +30,8 @@ public class LocalPoolThreadingTest extends AbstractStreamTest implements RxStre
         StreamId<Long> streamId = provide(source).withUniqueStreamId();
         Flowable<Long> stream = rxFrom(streamId);
         stream.subscribe(i -> SECONDS.sleep(10));
-        stream.test().awaitCount(4).assertValueAt(1, v -> 4 == v.intValue());
+        TestSubscriber<Long> test = stream.test();
+        test.awaitCount(4);
+        assertThat(test.values()).containsOnly(1L, 2L, 3L, 4L);
     }
-
-
-
-
-
 }

--- a/src/test/org/streamingpool/core/service/stream/CreatorStreamTest.java
+++ b/src/test/org/streamingpool/core/service/stream/CreatorStreamTest.java
@@ -29,9 +29,12 @@ import static org.mockito.Mockito.mock;
 import java.util.Arrays;
 import java.util.concurrent.Executors;
 
-import io.reactivex.schedulers.Schedulers;
 import org.junit.Test;
+
+import io.reactivex.Flowable;
+import io.reactivex.schedulers.Schedulers;
 import org.reactivestreams.Publisher;
+import org.streamingpool.core.conf.PoolConfiguration;
 import org.streamingpool.core.service.CycleInStreamDiscoveryDetectedException;
 import org.streamingpool.core.service.DiscoveryService;
 import org.streamingpool.core.service.StreamId;
@@ -40,8 +43,6 @@ import org.streamingpool.core.service.impl.ImmutableIdentifiedStreamCreator;
 import org.streamingpool.core.service.impl.LocalPool;
 import org.streamingpool.core.service.streamfactory.CreatorStreamFactory;
 import org.streamingpool.core.testing.NamedStreamId;
-
-import io.reactivex.Flowable;
 
 @SuppressWarnings("unchecked")
 /**
@@ -55,15 +56,17 @@ public class CreatorStreamTest {
     private static final StreamId<Object> ID_B = mock(StreamId.class);
     private static final Publisher<Object> STREAM_A = mock(Flowable.class);
     private static final Publisher<Object> STREAM_B = mock(Flowable.class);
+    protected static final PoolConfiguration POOL_CONFIGURATION = new PoolConfiguration(Schedulers.from(Executors.newSingleThreadExecutor()));
 
     private final IdentifiedStreamCreator<Object> creator = ImmutableIdentifiedStreamCreator.of(ID_A,
             discovery -> STREAM_A);
     private final CreatorStreamFactory factory = new CreatorStreamFactory(Arrays.asList(creator));
-    private final DiscoveryService discoveryService = new LocalPool(Arrays.asList(factory), Schedulers.from(Executors.newSingleThreadExecutor()));
+    private final DiscoveryService discoveryService = new LocalPool(Arrays.asList(factory),
+            POOL_CONFIGURATION);
 
     @Test(expected = CycleInStreamDiscoveryDetectedException.class)
     public void testCycleLoopDetectedUsingStreamCreators() {
-        DiscoveryService loopingDiscoveryService = new LocalPool(Arrays.asList(createLoopCreatorStreamFactory()), Schedulers.from(Executors.newSingleThreadExecutor()));
+        DiscoveryService loopingDiscoveryService = new LocalPool(Arrays.asList(createLoopCreatorStreamFactory()), POOL_CONFIGURATION);
 
         loopingDiscoveryService.discover(ID_A);
     }

--- a/src/test/org/streamingpool/core/service/stream/OverlapBufferStreamTest.java
+++ b/src/test/org/streamingpool/core/service/stream/OverlapBufferStreamTest.java
@@ -42,6 +42,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+import io.reactivex.Flowable;
+import io.reactivex.flowables.ConnectableFlowable;
+import io.reactivex.schedulers.TestScheduler;
+import io.reactivex.subscribers.TestSubscriber;
+import org.streamingpool.core.conf.PoolConfiguration;
 import org.streamingpool.core.service.StreamId;
 import org.streamingpool.core.service.impl.LocalPool;
 import org.streamingpool.core.service.streamfactory.DelayedStreamFactory;
@@ -50,24 +57,19 @@ import org.streamingpool.core.service.streamid.BufferSpecification;
 import org.streamingpool.core.service.streamid.BufferSpecification.EndStreamMatcher;
 import org.streamingpool.core.service.streamid.OverlapBufferStreamId;
 
-import com.google.common.collect.ImmutableSet;
-
-import io.reactivex.Flowable;
-import io.reactivex.flowables.ConnectableFlowable;
-import io.reactivex.schedulers.TestScheduler;
-import io.reactivex.subscribers.TestSubscriber;
-
 public class OverlapBufferStreamTest {
 
     private LocalPool pool;
     private TestSubscriber<List<Long>> testSubscriber;
-    private TestScheduler testScheduler;
+    private PoolConfiguration poolConfiguration;
+    private  TestScheduler testScheduler;
 
     @Before
     public void setUp() {
         OverlapBufferStreamFactory factory = new OverlapBufferStreamFactory();
         testScheduler = new TestScheduler();
-        pool = new LocalPool(asList(factory, new DelayedStreamFactory()), testScheduler);
+        poolConfiguration = new PoolConfiguration(testScheduler);
+        pool = new LocalPool(asList(factory, new DelayedStreamFactory()), poolConfiguration);
         testSubscriber = new TestSubscriber<>();
     }
 

--- a/src/test/org/streamingpool/core/service/streamfactory/FanOutStreamFactoryTest.java
+++ b/src/test/org/streamingpool/core/service/streamfactory/FanOutStreamFactoryTest.java
@@ -1,0 +1,99 @@
+package org.streamingpool.core.service.streamfactory;
+
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.schedulers.Schedulers;
+import io.reactivex.subscribers.TestSubscriber;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Schedules;
+import org.streamingpool.core.domain.backpressure.BackpressureStrategies;
+import org.streamingpool.core.service.StreamFactoryRegistry;
+import org.streamingpool.core.service.StreamId;
+import org.streamingpool.core.service.diagnostic.ErrorStreamId;
+import org.streamingpool.core.service.streamid.FanOutStreamId;
+import org.streamingpool.core.support.RxStreamSupport;
+import org.streamingpool.core.testing.AbstractStreamTest;
+
+public class FanOutStreamFactoryTest extends AbstractStreamTest implements RxStreamSupport {
+
+    @Autowired
+    private StreamFactoryRegistry streamFactoryRegistry;
+
+    @Before
+    public void setUp() {
+        streamFactoryRegistry.addIntercept(new FanOutStreamFactory());
+    }
+
+    @Test
+    public void testDrop() {
+        PublishProcessor<String> in = PublishProcessor.create();
+
+        StreamId<String> inStreamId = provide(in.onBackpressureBuffer()).withUniqueStreamId();
+
+        FanOutStreamId<String> fanOutStreamId = FanOutStreamId.fanOut(inStreamId, BackpressureStrategies.onBackpressureDrop());
+
+
+//        rxFrom(ErrorStreamId.of(fanOutStreamId)).subscribe(v -> System.out.println("ERROR SP: " + v));
+
+        TestSubscriber<String> fast = rxFrom(fanOutStreamId).doOnError(e -> System.out.println("ERROR: " + e)).test(0);
+        TestSubscriber<String> slow = rxFrom(fanOutStreamId).doOnError(e -> System.out.println("ERROR: " + e)).test(0);
+
+        slow.request(1);
+        fast.request(1);
+        in.onNext("A");
+        fast.request(1);
+        in.onNext("B");
+        fast.request(1);
+        in.onNext("C");
+        fast.request(1);
+        in.onNext("D");
+        fast.request(1);
+        slow.request(1);
+        in.onNext("E");
+        slow.request(1);
+        fast.request(1);
+        in.onNext("F");
+        slow.request(1);
+
+
+        sleep();
+        sleep();
+        sleep();
+        sleep();
+//        fast.awaitCount(2);
+//        slow.awaitCount(2);
+//        subscriber.assertValueCount(2);
+        System.out.println("fast: " + fast.values());
+        System.out.println("slow: " + slow.values());
+//        Assertions.assertThat(subscriber.values()).containsOnly("A", "C");
+
+
+//        TestSubscriber<String> subscriber = in.share().onBackpressureDrop().observeOn(Schedulers.computation()).test(0);
+//        TestSubscriber<String> subscriber = in
+//            .doOnNext(i -> System.out.println("1 received "+i))
+////            .onBackpressureDrop(i -> System.out.println("1st dropping "+i))
+//            .observeOn(Schedulers.newThread(), false, 1)
+//            .doOnNext(i -> System.out.println("2 received "+i))
+//            .share()
+//            .doOnNext(i -> System.out.println("3 received "+i))
+//            .onBackpressureDrop(i -> System.out.println("dropping "+i))
+//            .observeOn(Schedulers.newThread(), false, 1)
+//            .doOnNext(i -> System.out.println("4 received "+i))
+//            .doOnComplete(()-> System.out.println("completed"))
+//            .doOnError(i -> System.err.println("ERROR "+i))
+//            .test();
+
+    }
+
+    private void sleep() {
+        try {
+            Thread.sleep(100
+            );
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/test/org/streamingpool/core/service/streamfactory/FanOutStreamFactoryTest.java
+++ b/src/test/org/streamingpool/core/service/streamfactory/FanOutStreamFactoryTest.java
@@ -1,17 +1,23 @@
 package org.streamingpool.core.service.streamfactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.streamingpool.core.domain.backpressure.BackpressureBufferStrategy.BackpressureBufferOverflowStrategy.DROP_OLDEST;
+import static org.streamingpool.core.domain.backpressure.BackpressureStrategies.onBackpressureBuffer;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.reactivex.Flowable;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subscribers.TestSubscriber;
-import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.Schedules;
 import org.streamingpool.core.domain.backpressure.BackpressureStrategies;
 import org.streamingpool.core.service.StreamFactoryRegistry;
 import org.streamingpool.core.service.StreamId;
-import org.streamingpool.core.service.diagnostic.ErrorStreamId;
 import org.streamingpool.core.service.streamid.FanOutStreamId;
 import org.streamingpool.core.support.RxStreamSupport;
 import org.streamingpool.core.testing.AbstractStreamTest;
@@ -27,18 +33,20 @@ public class FanOutStreamFactoryTest extends AbstractStreamTest implements RxStr
     }
 
     @Test
-    public void testDrop() {
+    public void testOnBackpressureLatest() {
         PublishProcessor<String> in = PublishProcessor.create();
 
-        StreamId<String> inStreamId = provide(in.onBackpressureBuffer()).withUniqueStreamId();
+        StreamId<String> inStreamId = provide(in).withUniqueStreamId();
 
-        FanOutStreamId<String> fanOutStreamId = FanOutStreamId.fanOut(inStreamId, BackpressureStrategies.onBackpressureDrop());
+        FanOutStreamId<String> fanOutStreamId = FanOutStreamId
+                .fanOut(inStreamId, BackpressureStrategies.onBackpressureLatest());
 
-
-//        rxFrom(ErrorStreamId.of(fanOutStreamId)).subscribe(v -> System.out.println("ERROR SP: " + v));
-
-        TestSubscriber<String> fast = rxFrom(fanOutStreamId).doOnError(e -> System.out.println("ERROR: " + e)).test(0);
-        TestSubscriber<String> slow = rxFrom(fanOutStreamId).doOnError(e -> System.out.println("ERROR: " + e)).test(0);
+        TestSubscriber<String> fast = rxFrom(fanOutStreamId)
+                //.onBackpressureLatest() // this is necessary because a backpressure strategy needs to be applied after the observeOn applied in TrackKeppingDiscoveryService
+                .test(0);
+        TestSubscriber<String> slow = rxFrom(fanOutStreamId)
+                // .onBackpressureLatest()
+                .test(0);
 
         slow.request(1);
         fast.request(1);
@@ -50,50 +58,187 @@ public class FanOutStreamFactoryTest extends AbstractStreamTest implements RxStr
         fast.request(1);
         in.onNext("D");
         fast.request(1);
-        slow.request(1);
         in.onNext("E");
+        in.onNext("F");
+        in.onNext("G");
+        in.onNext("H");
+        sleep(); // necessary for the propagation between threads
         slow.request(1);
         fast.request(1);
-        in.onNext("F");
+        in.onNext("I");
         slow.request(1);
+        in.onNext("J");
 
-
-        sleep();
-        sleep();
-        sleep();
-        sleep();
-//        fast.awaitCount(2);
-//        slow.awaitCount(2);
-//        subscriber.assertValueCount(2);
+        fast.awaitCount(6);
+        slow.awaitCount(3);
+        fast.assertValueCount(6);
+        slow.assertValueCount(3);
         System.out.println("fast: " + fast.values());
         System.out.println("slow: " + slow.values());
-//        Assertions.assertThat(subscriber.values()).containsOnly("A", "C");
-
-
-//        TestSubscriber<String> subscriber = in.share().onBackpressureDrop().observeOn(Schedulers.computation()).test(0);
-//        TestSubscriber<String> subscriber = in
-//            .doOnNext(i -> System.out.println("1 received "+i))
-////            .onBackpressureDrop(i -> System.out.println("1st dropping "+i))
-//            .observeOn(Schedulers.newThread(), false, 1)
-//            .doOnNext(i -> System.out.println("2 received "+i))
-//            .share()
-//            .doOnNext(i -> System.out.println("3 received "+i))
-//            .onBackpressureDrop(i -> System.out.println("dropping "+i))
-//            .observeOn(Schedulers.newThread(), false, 1)
-//            .doOnNext(i -> System.out.println("4 received "+i))
-//            .doOnComplete(()-> System.out.println("completed"))
-//            .doOnError(i -> System.err.println("ERROR "+i))
-//            .test();
-
+        assertThat(fast.values()).containsOnly("A", "B", "C", "D", "E", "H");
+        assertThat(slow.values()).containsOnly("A", "H", "I");
     }
 
     private void sleep() {
         try {
-            Thread.sleep(100
-            );
+            Thread.sleep(100);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
+    }
+
+    @Test
+    public void testOnBackpressureDrop() {
+        PublishProcessor<String> in = PublishProcessor.create();
+
+        StreamId<String> inStreamId = provide(in).withUniqueStreamId();
+
+        FanOutStreamId<String> fanOutStreamId = FanOutStreamId
+                .fanOut(inStreamId, BackpressureStrategies.onBackpressureDrop());
+
+        TestSubscriber<String> fast = rxFrom(fanOutStreamId)
+                .test(0);
+        TestSubscriber<String> slow = rxFrom(fanOutStreamId)
+                .test(0);
+
+        slow.request(1);
+        fast.request(1);
+        in.onNext("A");
+        fast.request(1);
+        in.onNext("B");
+        fast.request(1);
+        in.onNext("C");
+        fast.request(1);
+        in.onNext("D");
+        fast.request(1);
+        in.onNext("E");
+        in.onNext("F");
+        in.onNext("G");
+        in.onNext("H");
+        sleep(); // necessary for the propagation between threads
+        slow.request(1);
+        fast.request(1);
+        in.onNext("I");
+        slow.request(1);
+        in.onNext("J");
+
+        fast.awaitCount(6);
+        slow.awaitCount(3);
+        fast.assertValueCount(6);
+        slow.assertValueCount(3);
+        System.out.println("fast: " + fast.values());
+        System.out.println("slow: " + slow.values());
+        assertThat(fast.values()).containsOnly("A", "B", "C", "D", "E", "I");
+        assertThat(slow.values()).containsOnly("A", "I", "J");
+    }
+
+    @Test
+    public void testOnBackpressureBuffer() {
+        PublishProcessor<String> in = PublishProcessor.create();
+
+        StreamId<String> inStreamId = provide(in).withUniqueStreamId();
+
+        FanOutStreamId<String> fanOutStreamId = FanOutStreamId.fanOut(inStreamId, onBackpressureBuffer(2,
+                DROP_OLDEST));
+
+        TestSubscriber<String> fast = rxFrom(fanOutStreamId)
+                .test(0);
+        TestSubscriber<String> slow = rxFrom(fanOutStreamId)
+                .test(0);
+
+        slow.request(1);
+        fast.request(1);
+        in.onNext("A");
+        fast.request(1);
+        in.onNext("B");
+        fast.request(1);
+        in.onNext("C");
+        fast.request(1);
+        in.onNext("D");
+        fast.request(1);
+        in.onNext("E");
+        in.onNext("F");
+        in.onNext("G");
+        in.onNext("H");
+        sleep(); // necessary for the propagation between threads
+        slow.request(1);
+        fast.request(3);
+        in.onNext("I");
+        in.onNext("J");
+        sleep(); // necessary for the propagation between threads
+        slow.request(1);
+
+        fast.awaitCount(8);
+        slow.awaitCount(3);
+        fast.assertValueCount(8);
+        slow.assertValueCount(3);
+        System.out.println("fast: " + fast.values());
+        System.out.println("slow: " + slow.values());
+        assertThat(fast.values()).containsOnly("A", "B", "C", "D", "E", "G", "H", "I");
+        assertThat(slow.values()).containsOnly("A", "G", "I");
+    }
+
+    @Test
+    public void testWithPureFlowable() {
+        PublishProcessor<String> in = PublishProcessor.create();
+
+        Flowable<String> input = in
+                .observeOn(Schedulers.newThread(), false)
+                .share()
+                .observeOn(Schedulers.newThread(), false)
+                .onBackpressureLatest();
+
+        TestSubscriber<String> fast = input
+                .doOnError(e -> System.out.println("ERROR: " + e))
+                .test(0);
+        TestSubscriber<String> slow = input
+                .doOnError(e -> System.out.println("ERROR: " + e))
+                .test(0);
+
+        slow.request(1);
+        fast.request(1);
+        in.onNext("A");
+        fast.request(1);
+        in.onNext("B");
+        fast.request(1);
+        in.onNext("C");
+        fast.request(1);
+        in.onNext("D");
+        fast.request(1);
+        in.onNext("E");
+        in.onNext("F");
+        in.onNext("G");
+        in.onNext("H");
+        sleep(); // necessary for the propagation between threads
+        slow.request(1);
+        fast.request(1);
+        in.onNext("I");
+        slow.request(1);
+
+        fast.awaitCount(6);
+        slow.awaitCount(3);
+        fast.assertValueCount(6);
+        slow.assertValueCount(3);
+        System.out.println("fast: " + fast.values());
+        System.out.println("slow: " + slow.values());
+        assertThat(fast.values()).containsOnly("A", "B", "C", "D", "E", "H");
+        assertThat(slow.values()).containsOnly("A", "H", "I");
+    }
+
+    @Test
+    public void testShareOnColdStream() {
+        AtomicInteger emissionCounter = new AtomicInteger();
+        Flowable<Long> in = Flowable.rangeLong(1, 10)
+                .doOnNext(i -> emissionCounter.incrementAndGet())
+                .share();
+
+        TestSubscriber<Long> sub1 = in.observeOn(Schedulers.newThread()).test();
+        TestSubscriber<Long> sub2 = in.observeOn(Schedulers.newThread()).test();
+
+        sub1.awaitTerminalEvent();
+        sub2.awaitTerminalEvent();
+
+        Assert.assertEquals(20, emissionCounter.get());
     }
 
 }


### PR DESCRIPTION
Hi :)

due to the introduction of the new version of japc streams, the streams generated by the stream factory are not shared by default. There are various reasons for this behavior, but sometimes a shared stream is what you want.. one idea is to create a FanOutStreamId that shares (in Rx terminology) the target StreamId. Since the fanout would turn a cold stream into a hot stream, we're thinking to force to choose a backpressure strategy (or take the default one).

This branch is meant to be used to propose ideas on how to implement this feature and whether is useful or not :)

@JanetQC @timart1n @Macok @makemeunsee @matgabriel @kaifox @soper07 