### PR TITLE
Updated FlattenedStreamId to accept subclasses of Iterable

### DIFF
--- a/src/java/org/streamingpool/core/service/streamfactory/FlattenedStreamFactory.java
+++ b/src/java/org/streamingpool/core/service/streamfactory/FlattenedStreamFactory.java
@@ -51,7 +51,7 @@ public class FlattenedStreamFactory implements StreamFactory {
     }
 
     private <T> ErrorStreamPair<T> createFlattenedStream(FlattenedStreamId<T> id, DiscoveryService discoveryService) {
-        Flowable<Iterable<? extends T>> sourceStream = Flowable.fromPublisher(discoveryService.discover(id.sourceStreamId()));
+        Flowable<? extends Iterable<? extends T>> sourceStream = Flowable.fromPublisher(discoveryService.discover(id.sourceStreamId()));
 
         return ErrorStreamPair.ofData(sourceStream.flatMap(iterable -> {
             Stream<? extends T> stream = StreamSupport.stream(iterable.spliterator(), false).filter(Objects::nonNull);

--- a/src/java/org/streamingpool/core/service/streamid/FlattenedStreamId.java
+++ b/src/java/org/streamingpool/core/service/streamid/FlattenedStreamId.java
@@ -36,17 +36,17 @@ import static java.util.Objects.requireNonNull;
 public class FlattenedStreamId<T> implements StreamId<T> {
     private static final long serialVersionUID = 1L;
 
-    private final StreamId<Iterable<? extends T>> sourceStreamId;
+    private final StreamId<? extends Iterable<? extends T>> sourceStreamId;
 
-    public static <T> FlattenedStreamId<T> flatten(StreamId<Iterable<? extends T>> sourceStreamId) {
+    public static <T> FlattenedStreamId<T> flatten(StreamId<? extends Iterable<? extends T>> sourceStreamId) {
         return new FlattenedStreamId<>(sourceStreamId);
     }
 
-    public FlattenedStreamId(StreamId<Iterable<? extends T>> sourceStreamId) {
+    public FlattenedStreamId(StreamId<? extends Iterable<? extends T>> sourceStreamId) {
         this.sourceStreamId = requireNonNull(sourceStreamId, "sourceStreamId must not be null");
     }
 
-    public StreamId<Iterable<? extends T>> sourceStreamId() {
+    public StreamId<? extends Iterable<? extends T>> sourceStreamId() {
         return sourceStreamId;
     }
 


### PR DESCRIPTION
Currently FlattenedStreamId accepts a source stream id as "StreamId<Iterable<? extends T>>". That creates a problem if we want to pass "StreamId<List<? extends T>>". Therefore we changed Iterable to "? extends Iterable".